### PR TITLE
[perf]: tweak model loading time

### DIFF
--- a/pix2pix/infer.py
+++ b/pix2pix/infer.py
@@ -44,7 +44,8 @@ def infer(img):
     """inference function, accepts an abstract image file return generated image"""
     home_dir = get_directory()
     # load model
-    gen_model = load_model(home_dir + "/models/generator_model.h5")
+    backend.clear_session()
+    gen_model = load_model(home_dir + "/models/generator_model.h5", compile=False)
     img = np.array(Image.open(img))
     s_time = time.time()
     result = gen_model.predict(img.reshape(1, 256, 256, 3))


### PR DESCRIPTION
shaves off significant amount of time due to model loading delay

```bash
Total time: 2.32713 s
File: <ipython-input-81-200c764f80c4>
Function: infer at line 1
```

vs
```bash
Total time: 7.49379 s
File: <ipython-input-97-42e3b4bfe656>


