### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/dlrs-template-openfaas/template/python3-dlrs/Dockerfile
+++ b/dlrs-template-openfaas/template/python3-dlrs/Dockerfile
@@ -13,7 +13,7 @@ COPY function /home/dlrsfunc/function
 
 WORKDIR /home/dlrsfunc/function
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 RUN touch __init__.py
 RUN chown dlrsfunc /home/dlrsfunc/function

--- a/github-issue-classification/docker/Dockerfile.infer
+++ b/github-issue-classification/docker/Dockerfile.infer
@@ -17,7 +17,7 @@ FROM clearlinux/stacks-dlrs-mkl
 
 WORKDIR /workdir/
 COPY . /workdir/
-RUN pip install -r /workdir/docker/requirements.txt
+RUN pip install --no-cache-dir -r /workdir/docker/requirements.txt
 RUN echo -e "\e[31mThis server should only be used for debugging purposes."
 ENTRYPOINT ["hypercorn","-kuvloop", "-b0.0.0.0:5059", "--debug", "-w8"]
 CMD ["/workdir/python/rest:app"]

--- a/github-issue-classification/docker/Dockerfile.train
+++ b/github-issue-classification/docker/Dockerfile.train
@@ -19,4 +19,4 @@ WORKDIR /tmp/
 
 COPY requirements_train.txt .
 
-RUN pip install -r requirements_train.txt
+RUN pip install --no-cache-dir -r requirements_train.txt

--- a/healthcare/ich_segmentation/Dockerfile
+++ b/healthcare/ich_segmentation/Dockerfile
@@ -2,7 +2,7 @@ FROM clearlinux/stacks-dlrs_2-mkl
 
 RUN swupd clean && swupd bundle-add vim
 
-RUN pip install \
+RUN pip install --no-cache-dir \
     matplotlib seaborn \
     pillow sklearn nibabel \
     google-cloud-storage \

--- a/image_recog/Dockerfile
+++ b/image_recog/Dockerfile
@@ -2,7 +2,7 @@ FROM clearlinux/stacks-pytorch-mkl:v0.4.0
 
 WORKDIR /efficient_net/
 COPY . /efficient_net/
-RUN /opt/conda/bin/pip install -r requirements.txt
+RUN /opt/conda/bin/pip install --no-cache-dir -r requirements.txt
 RUN echo -e "\e[31mThis server should only be used for debugging purposes."
 ENTRYPOINT ["/opt/conda/bin/python", "-c ", "hypercorn","-kuvloop", "-b0.0.0.0:5059", "--debug", "-w8"]
 CMD ["rest:app"]

--- a/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
+++ b/kubeflow/dlrs-seldon/docker/Dockerfile_openvino_base
@@ -1,7 +1,7 @@
 FROM sysstacks/dlrs-serving-ubuntu:v0.9.0
 
-RUN pip install jaeger-client==3.13.0 seldon-core tornado>=5.0\
-    && pip install --upgrade setuptools \
+RUN pip install --no-cache-dir jaeger-client==3.13.0 seldon-core tornado>=5.0\
+    && pip install --no-cache-dir --upgrade setuptools \
     && sed -i "s/max_workers=10/max_workers=1/g" /usr/lib/python3.7/site-packages/seldon_core/wrapper.py
 
 RUN git clone https://github.com/SeldonIO/seldon-core.git /opt/seldon-core \

--- a/pix2pix/Dockerfile.infer
+++ b/pix2pix/Dockerfile.infer
@@ -6,7 +6,7 @@ COPY ./. /pix2pix
 
 RUN swupd bundle-add devpkg-libjpeg-turbo \
     && CFLAGS="${CFLAGS} -mavx2" pip install --no-cache-dir --compile pillow-simd \
-    && cd /pix2pix && pip install -r requirements.txt
+    && cd /pix2pix && pip install --no-cache-dir -r requirements.txt
 
 WORKDIR /pix2pix
 ENTRYPOINT ["python", "-W", "ignore", "rest.py"]

--- a/pix2pix/Dockerfile.train
+++ b/pix2pix/Dockerfile.train
@@ -5,6 +5,6 @@ COPY ./. /pix2pix
 
 RUN swupd bundle-add devpkg-libjpeg-turbo \
     && CFLAGS="${CFLAGS} -mavx2" pip install --no-cache-dir --compile pillow-simd \
-    && cd /pix2pix && pip install -r requirements.txt
+    && cd /pix2pix && pip install --no-cache-dir -r requirements.txt
 
 CMD bash

--- a/pix2pix/fn/template/Dockerfile
+++ b/pix2pix/fn/template/Dockerfile
@@ -1,12 +1,12 @@
 FROM clearlinux/stacks-dlrs-oss:v0.5.1
-RUN pip install fdk
+RUN pip install --no-cache-dir fdk
 WORKDIR workspace
 RUN git clone https://github.com/intel/stacks-usecase.git
 COPY func.py .
 RUN cp stacks-usecase/pix2pix/infer.py . && cp -a stacks-usecase/pix2pix/scripts . && rm -rf stacks-usecase
 COPY requirements.txt .
 COPY generator_model.h5 models/
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 RUN touch __init__.py scripts/__init__.py
 ENV PYTHONPATH=$PYTHONPATH:/workspace/:/workspace/scripts/
 ENTRYPOINT ["fdk", "func.py", "handler"]

--- a/zeppelin-notebook/Dockerfile
+++ b/zeppelin-notebook/Dockerfile
@@ -20,7 +20,7 @@ FROM clearlinux/stacks-dars-mkl:v0.1.2
 LABEL maintainer=otc-swstacks@intel.com
 
 COPY requirements.txt /
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENV SPARK_MASTER_PORT=7077
 ENV ZEPPELIN_HOME /opt/zeppelin


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>